### PR TITLE
release: links redesign, footer cleanup, more landing motion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,10 +15,10 @@
         "@fontsource-variable/space-grotesk": "^5.2.5",
         "@iconify-json/lucide": "^1.2.44",
         "@iconify-json/simple-icons": "^1.2.38",
-        "@rollup/plugin-yaml": "^4.1.2",
+        "@rollup/plugin-yaml": "^5.0.0",
         "astro": "^7.0.6",
         "astro-icon": "^1.1.5",
-        "typescript": "^5.8.3"
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@antfu/install-pkg": {
@@ -2223,13 +2223,13 @@
       "license": "MIT"
     },
     "node_modules/@rollup/plugin-yaml": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-yaml/-/plugin-yaml-4.1.2.tgz",
-      "integrity": "sha512-RpupciIeZMUqhgFE97ba0s98mOFS7CWzN3EJNhJkqSv9XLlWYtwVdtE6cDw6ASOF/sZVFS7kRJXftaqM2Vakdw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-yaml/-/plugin-yaml-5.0.0.tgz",
+      "integrity": "sha512-9XOiRGYJjDwmEwR15kuxw+RytZFKtEWshoXuITrtS6+57BVMQMzDfhmSO/xfQOAY5psQv1IrxhQTUqPNppe4lQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rollup/pluginutils": "^5.0.1",
+        "@rollup/pluginutils": "^5.3.0",
         "js-yaml": "^4.1.0",
         "tosource": "^2.0.0-alpha.3"
       },
@@ -2237,7 +2237,7 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+        "rollup": "^2.78.0||^3.0.0||^4.0.0"
       },
       "peerDependenciesMeta": {
         "rollup": {
@@ -5449,9 +5449,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "@fontsource-variable/space-grotesk": "^5.2.5",
     "@iconify-json/lucide": "^1.2.44",
     "@iconify-json/simple-icons": "^1.2.38",
-    "@rollup/plugin-yaml": "^4.1.2",
+    "@rollup/plugin-yaml": "^5.0.0",
     "astro": "^7.0.6",
     "astro-icon": "^1.1.5",
-    "typescript": "^5.8.3"
+    "typescript": "^6.0.3"
   },
   "allowScripts": {
     "sharp@0.34.5": true,

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -5,11 +5,6 @@ import { site } from '../config/site';
 
 <footer>
   <div class="wrap inner">
-    <nav aria-label="Footer">
-      <a href={site.docs} rel="noopener noreferrer">{copy.links.docs}</a>
-      <a href={site.blog} rel="noopener noreferrer">{copy.links.blog}</a>
-      <a href={site.status} rel="noopener noreferrer">{copy.links.status}</a>
-    </nav>
     <a class="kofi" href={site.kofi} rel="noopener noreferrer">
       <img src={site.kofiButton} alt={copy.footer.kofi} height="36" loading="lazy" />
     </a>
@@ -35,21 +30,12 @@ import { site } from '../config/site';
     text-align: center;
   }
 
-  nav {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: var(--space-l);
-  }
-
-  nav a,
   .credit a {
     color: var(--text-muted);
     text-decoration: none;
     transition: color var(--dur-fast) var(--ease);
   }
 
-  nav a:hover,
   .credit a:hover {
     color: var(--accent);
   }

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -63,12 +63,17 @@ import logo from '../assets/logo.png';
     height: auto;
     border-radius: 50%;
     box-shadow: var(--glow);
-    animation: levitate 6s ease-in-out infinite alternate;
   }
 
   @keyframes levitate {
     to {
       transform: translateY(-10px);
+    }
+  }
+
+  @keyframes breathe {
+    to {
+      box-shadow: var(--glow-strong);
     }
   }
 
@@ -85,10 +90,31 @@ import logo from '../assets/logo.png';
     font-size: var(--step-5);
     font-weight: 700;
     letter-spacing: -0.02em;
-    background: linear-gradient(100deg, var(--heading) 55%, var(--accent));
+    /* sheen band layered over the brand gradient; only the band's position animates */
+    background:
+      linear-gradient(100deg, transparent 44%, rgba(255, 255, 255, 0.4) 50%, transparent 56%)
+        no-repeat,
+      linear-gradient(100deg, var(--heading) 55%, var(--accent));
+    background-size:
+      250% 100%,
+      100% 100%;
     -webkit-background-clip: text;
     background-clip: text;
     color: transparent;
+  }
+
+  @keyframes sheen {
+    0%,
+    55% {
+      background-position:
+        115% 0,
+        0 0;
+    }
+    100% {
+      background-position:
+        -35% 0,
+        0 0;
+    }
   }
 
   .tagline {
@@ -106,6 +132,8 @@ import logo from '../assets/logo.png';
   }
 
   .btn {
+    position: relative;
+    overflow: hidden;
     display: inline-flex;
     align-items: center;
     gap: var(--space-xs);
@@ -145,6 +173,25 @@ import logo from '../assets/logo.png';
     box-shadow: var(--glow);
   }
 
+  /* light sweep across the primary button on hover */
+  .btn-primary::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+      105deg,
+      transparent 40%,
+      rgba(255, 255, 255, 0.35) 50%,
+      transparent 60%
+    );
+    transform: translateX(-120%);
+  }
+
+  .btn-primary:hover::after {
+    transform: translateX(120%);
+    transition: transform 600ms var(--ease);
+  }
+
   /* staggered entrance */
   .hero-inner > * {
     animation: rise var(--dur-slow) var(--ease) both;
@@ -168,6 +215,21 @@ import logo from '../assets/logo.png';
       opacity: 0;
       transform: translateY(22px);
     }
+  }
+
+  /* continuous motion layered on top of the entrance; the .hero-inner >
+     prefix is needed to out-rank the stagger rule above */
+  .hero-inner > .logo {
+    animation:
+      rise var(--dur-slow) var(--ease) both,
+      levitate 6s ease-in-out var(--dur-slow) infinite alternate,
+      breathe 6s ease-in-out var(--dur-slow) infinite alternate;
+  }
+
+  .hero-inner > .title {
+    animation:
+      rise var(--dur-slow) var(--ease) both,
+      sheen 8s var(--ease) infinite;
   }
 
   .scroll-cue {
@@ -196,10 +258,19 @@ import logo from '../assets/logo.png';
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .logo,
+    .hero-inner > .logo,
+    .hero-inner > .title,
     .hero-inner > *,
     .scroll-cue {
       animation: none;
+    }
+
+    .btn:hover {
+      transform: none;
+    }
+
+    .btn-primary::after {
+      display: none;
     }
   }
 </style>

--- a/src/components/LinksStrip.astro
+++ b/src/components/LinksStrip.astro
@@ -3,27 +3,36 @@ import { Icon } from 'astro-icon/components';
 import copy from '../content/copy.yml';
 import { site } from '../config/site';
 
+// Display handles are derived from the canonical facts in site.ts.
+const host = (url: string) => url.replace(/^https?:\/\//, '');
+const handle = (url: string) => '@' + (url.split('/').pop() ?? '').replace(/^@/, '');
+
 const links = [
-  { href: `mailto:${site.email}`, label: copy.links.email, icon: 'lucide:mail', external: false },
-  { href: site.docs, label: copy.links.docs, icon: 'lucide:book-open', external: true },
-  { href: site.blog, label: copy.links.blog, icon: 'lucide:rss', external: true },
-  { href: site.mastodon, label: copy.links.mastodon, icon: 'simple-icons:mastodon', external: true },
-  { href: site.steam, label: copy.links.steam, icon: 'simple-icons:steam', external: true },
-  { href: site.github, label: copy.links.github, icon: 'simple-icons:github', external: true },
-  { href: site.status, label: copy.links.status, icon: 'lucide:activity', external: true },
+  { href: `mailto:${site.email}`, label: copy.links.email, sub: site.email, icon: 'lucide:mail', external: false },
+  { href: site.docs, label: copy.links.docs, sub: host(site.docs), icon: 'lucide:book-open', external: true },
+  { href: site.blog, label: copy.links.blog, sub: host(site.blog), icon: 'lucide:rss', external: true },
+  { href: site.mastodon, label: copy.links.mastodon, sub: handle(site.mastodon), icon: 'simple-icons:mastodon', external: true },
+  { href: site.steam, label: copy.links.steam, sub: site.steam.split('/').pop(), icon: 'simple-icons:steam', external: true },
+  { href: site.github, label: copy.links.github, sub: handle(site.github), icon: 'simple-icons:github', external: true },
+  { href: site.status, label: copy.links.status, sub: host(site.status), icon: 'lucide:activity', external: true },
 ];
 ---
 
 <section class="links" aria-labelledby="links-heading">
   <div class="wrap">
     <h2 id="links-heading" data-reveal>{copy.links.heading}</h2>
-    <ul data-reveal>
+    <ul>
       {
-        links.map(({ href, label, icon, external }) => (
-          <li>
+        links.map(({ href, label, sub, icon, external }) => (
+          <li data-reveal>
             <a {href} rel={external ? 'noopener noreferrer' : undefined}>
-              <Icon name={icon} />
-              {label}
+              <span class="chip">
+                <Icon name={icon} />
+              </span>
+              <span class="txt">
+                <span class="label">{label}</span>
+                <span class="sub">{sub}</span>
+              </span>
             </a>
           </li>
         ))
@@ -50,19 +59,53 @@ const links = [
     margin-top: var(--space-xl);
     padding: 0;
     list-style: none;
+  }
+
+  li {
+    width: min(100%, 16.25rem);
+  }
+
+  /* cycle the brand accents across the cards */
+  li:nth-child(3n + 1) {
+    --card-accent: var(--accent);
+  }
+  li:nth-child(3n + 2) {
+    --card-accent: var(--accent-2);
+  }
+  li:nth-child(3n) {
+    --card-accent: var(--accent-3);
+  }
+
+  /* staggered reveal */
+  li:nth-child(2) {
+    --reveal-delay: 60ms;
+  }
+  li:nth-child(3) {
     --reveal-delay: 120ms;
+  }
+  li:nth-child(4) {
+    --reveal-delay: 180ms;
+  }
+  li:nth-child(5) {
+    --reveal-delay: 240ms;
+  }
+  li:nth-child(6) {
+    --reveal-delay: 300ms;
+  }
+  li:nth-child(7) {
+    --reveal-delay: 360ms;
   }
 
   a {
-    display: inline-flex;
+    display: flex;
     align-items: center;
-    gap: var(--space-xs);
-    padding: 0.6rem 1.2rem;
+    gap: var(--space-s);
+    height: 100%;
+    padding: 0.7rem 0.9rem;
     border: 1px solid var(--border);
-    border-radius: var(--radius-full);
+    border-radius: var(--radius);
     background: var(--surface);
-    color: var(--text);
-    font-weight: 500;
+    text-align: left;
     text-decoration: none;
     transition:
       transform var(--dur-fast) var(--ease),
@@ -71,19 +114,52 @@ const links = [
   }
 
   a:hover {
-    transform: translateY(-2px);
-    border-color: var(--accent);
+    transform: translateY(-3px);
+    border-color: var(--card-accent);
     background: var(--surface-hover);
   }
 
-  a [data-icon] {
-    width: 1.15rem;
-    height: 1.15rem;
-    color: var(--accent);
+  .chip {
+    display: inline-flex;
+    flex-shrink: 0;
+    padding: 0.55rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-full);
+    background: color-mix(in srgb, var(--card-accent) 10%, transparent);
+    color: var(--card-accent);
+    transition: transform var(--dur-fast) var(--ease);
+  }
+
+  a:hover .chip {
+    transform: scale(1.1);
+  }
+
+  .chip [data-icon] {
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+
+  .txt {
+    display: grid;
+    min-width: 0;
+  }
+
+  .label {
+    color: var(--text);
+    font-weight: 600;
+  }
+
+  .sub {
+    color: var(--text-muted);
+    font-size: 0.85rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   @media (prefers-reduced-motion: reduce) {
-    a:hover {
+    a:hover,
+    a:hover .chip {
       transform: none;
     }
   }

--- a/src/components/Pillars.astro
+++ b/src/components/Pillars.astro
@@ -106,6 +106,22 @@ const icons: Record<string, string[]> = {
     border-radius: var(--radius-full);
     background: var(--surface);
     color: var(--accent);
+    transition: transform var(--dur) var(--ease);
+  }
+
+  /* the icon trio hops in sequence when the card is hovered */
+  .card:hover .chip {
+    transform: translateY(-4px);
+  }
+
+  .card:hover .chip:nth-child(2),
+  .chip:nth-child(2) {
+    transition-delay: 60ms;
+  }
+
+  .card:hover .chip:nth-child(3),
+  .chip:nth-child(3) {
+    transition-delay: 120ms;
   }
 
   .chip:nth-child(2) {
@@ -122,7 +138,8 @@ const icons: Record<string, string[]> = {
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .card:hover {
+    .card:hover,
+    .card:hover .chip {
       transform: none;
     }
   }

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,5 +1,9 @@
 /// <reference types="astro/client" />
 
+// Side-effect CSS imports (TypeScript 6 requires declarations for these).
+declare module '@fontsource-variable/inter';
+declare module '@fontsource-variable/space-grotesk';
+
 declare module '*.yml' {
   const data: any;
   export default data;

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -6,7 +6,6 @@ import '../styles/tokens.css';
 import '../styles/global.css';
 import Seo from '../components/Seo.astro';
 import copy from '../content/copy.yml';
-import { site } from '../config/site';
 
 interface Props {
   title?: string;

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -22,6 +22,7 @@
   --accent-3: #60a5fa;
   --accent-contrast: #052e2a;
   --glow: 0 0 40px rgba(94, 234, 212, 0.15);
+  --glow-strong: 0 0 70px rgba(94, 234, 212, 0.3);
 
   /* typography */
   --font-display: 'Space Grotesk Variable', 'Space Grotesk', system-ui, sans-serif;
@@ -76,4 +77,5 @@
   --accent-3: #2563eb;
   --accent-contrast: #f0fdfa;
   --glow: 0 0 40px rgba(13, 148, 136, 0.12);
+  --glow-strong: 0 0 70px rgba(13, 148, 136, 0.24);
 }


### PR DESCRIPTION
## Changes

- **deps**: \`@rollup/plugin-yaml\` 4 → 5, \`typescript\` 5.9 → 6.0 (declarations added for side-effect font CSS imports required by TS 6)
- **footer**: removed the Documentation / Blog / Service Status nav — those live only in the links section now; footer keeps Ko-fi and the credit line
- **links section**: "Find us around the web" redesigned from a single row of pills into a centered card grid; each card shows icon, service name and the real handle/domain (derived from \`site.ts\`, no new hardcoded facts)
- **landing motion**: breathing glow on the logo, periodic sheen across the hero title, light sweep on the primary CTA on hover, staggered icon hop on pillar-card hover — all CSS-only, CSP-safe, disabled under \`prefers-reduced-motion\`
- **fix**: the logo levitate animation had been dead since the rewrite (overridden by the higher-specificity hero stagger rule); now restored

## Verification

- \`astro check\` clean on TS 6, \`npm audit\` 0 vulnerabilities
- Browser-verified (dark/light/mobile screenshots): zero CSP violations, theme toggle OK, reduced-motion fully static (0 running animations, all content visible), email card no longer truncates
- Lighthouse desktop: 100 / 100 / 100 / 100
