### PR TITLE
release: dark-theme sheen fix, livelier aurora

### DIFF
--- a/src/components/Aurora.astro
+++ b/src/components/Aurora.astro
@@ -31,7 +31,7 @@
     top: -25vmax;
     left: -18vmax;
     background: radial-gradient(closest-side, rgba(94, 234, 212, 0.16), transparent 70%);
-    animation: drift-a 75s var(--ease) infinite alternate;
+    animation: drift-a 34s ease-in-out infinite alternate;
   }
 
   .blob-b {
@@ -40,7 +40,7 @@
     top: 10vmax;
     right: -22vmax;
     background: radial-gradient(closest-side, rgba(167, 139, 250, 0.14), transparent 70%);
-    animation: drift-b 90s var(--ease) infinite alternate;
+    animation: drift-b 46s ease-in-out infinite alternate;
   }
 
   .blob-c {
@@ -49,24 +49,41 @@
     bottom: -20vmax;
     left: 20vmax;
     background: radial-gradient(closest-side, rgba(96, 165, 250, 0.12), transparent 70%);
-    animation: drift-c 60s var(--ease) infinite alternate;
+    animation: drift-c 28s ease-in-out infinite alternate;
   }
 
+  /* wandering two-waypoint paths with a soft glow pulse — transform and
+     opacity only, so everything stays on the compositor */
   @keyframes drift-a {
+    50% {
+      transform: translate3d(11vw, 4vh, 0) scale(1.1);
+      opacity: 0.7;
+    }
     to {
-      transform: translate3d(9vw, 7vh, 0) scale(1.15);
+      transform: translate3d(5vw, 11vh, 0) scale(1.2);
+      opacity: 1;
     }
   }
 
   @keyframes drift-b {
+    50% {
+      transform: translate3d(-10vw, 3vh, 0) scale(1.15);
+      opacity: 0.75;
+    }
     to {
-      transform: translate3d(-7vw, 9vh, 0) scale(1.1);
+      transform: translate3d(-4vw, 12vh, 0) scale(1.05);
+      opacity: 1;
     }
   }
 
   @keyframes drift-c {
+    50% {
+      transform: translate3d(9vw, -3vh, 0) scale(1.08);
+      opacity: 0.75;
+    }
     to {
-      transform: translate3d(6vw, -8vh, 0) scale(1.2);
+      transform: translate3d(3vw, -11vh, 0) scale(1.25);
+      opacity: 1;
     }
   }
 
@@ -119,8 +136,9 @@
     }
   }
 
-  /* light theme: pastel blobs, no stars */
-  :global([data-theme='light']) .blob {
+  /* light theme: pastel blobs, no stars — damped on the container because
+     the drift keyframes animate the blobs' own opacity */
+  :global([data-theme='light']) .aurora {
     opacity: 0.55;
   }
 

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -92,7 +92,7 @@ import logo from '../assets/logo.png';
     letter-spacing: -0.02em;
     /* sheen band layered over the brand gradient; only the band's position animates */
     background:
-      linear-gradient(100deg, transparent 44%, rgba(255, 255, 255, 0.4) 50%, transparent 56%)
+      linear-gradient(100deg, transparent 44%, var(--title-sheen) 50%, transparent 56%)
         no-repeat,
       linear-gradient(100deg, var(--heading) 55%, var(--accent));
     background-size:

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -23,6 +23,8 @@
   --accent-contrast: #052e2a;
   --glow: 0 0 40px rgba(94, 234, 212, 0.15);
   --glow-strong: 0 0 70px rgba(94, 234, 212, 0.3);
+  /* hero title sheen band — must contrast with the near-white dark-theme heading */
+  --title-sheen: rgba(167, 139, 250, 0.55);
 
   /* typography */
   --font-display: 'Space Grotesk Variable', 'Space Grotesk', system-ui, sans-serif;
@@ -78,4 +80,5 @@
   --accent-contrast: #f0fdfa;
   --glow: 0 0 40px rgba(13, 148, 136, 0.12);
   --glow-strong: 0 0 70px rgba(13, 148, 136, 0.24);
+  --title-sheen: rgba(255, 255, 255, 0.5);
 }


### PR DESCRIPTION
## Changes

- **fix**: the hero title sheen was a plain white band — invisible over the near-white dark-theme heading. It is now the `--title-sheen` theme token: violet glint on dark, white sweep on light.
- **aurora**: drift cycles roughly halved (34/46/28s), blobs follow two-waypoint wandering paths instead of a straight ping-pong, and their glow pulses gently. Still pure CSS, transform + opacity only (compositor-friendly). Light-theme damping moved from the blobs to the container because the keyframes now animate blob opacity.

## Verification

- Browser-verified: sheen band visible mid-sweep on both themes (screenshots), blob transform delta ~6px/s, light theme damped at 0.55, reduced motion fully static (0 running animations)
- `astro check` clean, build passes